### PR TITLE
Fix np.concatenate not working properly

### DIFF
--- a/shannon_energy_rpd.py
+++ b/shannon_energy_rpd.py
@@ -131,7 +131,7 @@ for i in idx:
     highs = np.arange(i+1, i+search_window_half+1)
     if highs[-1] > len(EKG):
         highs = np.delete(highs, np.arange(np.where(highs == len(EKG))[0], len(highs)+1))
-    ekg_window = np.concatenate(lows, i, highs)
+    ekg_window = np.concatenate([lows, i, highs])
     idx_search.append(ekg_window)
     ekg_window_wave = EKG[ekg_window]
     id_maxes = np.append(id_maxes, ekg_window[np.where(ekg_window_wave == np.max(ekg_window_wave))[0]])


### PR DESCRIPTION
I believe this is a bug in your code. I've adapted it to some data I'm currently working with and some of the ECG signals crashed this code. Changing this line to concatenate properly appears to fix the problem. I haven't looked at the algorithm at all, but suspect this is what is meant to happen anyway.